### PR TITLE
Expand scope of `test_identify_cocos`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,9 @@ fallback_version = "0.1.0"
 [tool.isort]
 profile = "black"
 
+[tool.ruff]
+select = ["E", "F", "W", "RUF"]
+
 [tool.coverage.run]
 relative_files = true
 omit = [

--- a/src/pyloidal/cocos.py
+++ b/src/pyloidal/cocos.py
@@ -143,16 +143,18 @@ def identify_cocos(
 
     if clockwise_phi is None:
         return tuple(
-            itertools.chain.from_iterable(
-                identify_cocos(
-                    b_toroidal,
-                    plasma_current,
-                    safety_factor,
-                    poloidal_flux,
-                    x,
-                    minor_radii,
+            sorted(
+                itertools.chain.from_iterable(
+                    identify_cocos(
+                        b_toroidal,
+                        plasma_current,
+                        safety_factor,
+                        poloidal_flux,
+                        x,
+                        minor_radii,
+                    )
+                    for x in (True, False)
                 )
-                for x in (True, False)
             )
         )
 
@@ -169,8 +171,10 @@ def identify_cocos(
     if minor_radii is None:
         # Return both variants if not provided with minor radii
         return tuple(
-            sigma_to_cocos(sigma_bp, sigma_rpz, sigma_rtp, psi_by_2pi=x)
-            for x in (True, False)
+            sorted(
+                sigma_to_cocos(sigma_bp, sigma_rpz, sigma_rtp, psi_by_2pi=x)
+                for x in (True, False)
+            )
         )
 
     index = np.argmin(np.abs(safety_factor))


### PR DESCRIPTION
Improved `test_identify_cocos` so it now covers missing arguments and the antiparallel $B_T$ / $I_P$ case, although for simplicity it's only testing $B_T < 0, I_P > 0$.

Mostly resolves Issue https://github.com/PlasmaFAIR/pyloidal/issues/5.

Additionally now sorts outputs of `identify_cocos`.