### PR TITLE
Upgrade linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,14 +20,14 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install .[lint]
-      - name: Run Black
+      - name: Run ruff formatter
         if: always()
         run: |
-          black --check --verbose src tests
-      - name: Run Ruff
+          ruff format --check src tests
+      - name: Run ruff linter
         if: always()
         run: |
-          ruff check src
+          ruff check src tests
       - name: Run MyPy
         if: always()
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ select = [
     "E", # pycodestyle error
     "W", # pycodestyle warning
     "I", # isort
+    "PT", # flake8-pytest-style
     "RUF", # ruff specific
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,19 @@ select = [
     "W", # pycodestyle warning
     "I", # isort
     "PT", # flake8-pytest-style
+    "B", # flake8-bugbear
+    "A", # flake8-builtins
+    "C4", # flake8-comprehensions
+    "EM", # flake8-errmsg
+    "T10", # flake8-debugger
+    "PTH", # flake8-use-pathlib
+    "SIM", # flake8-simplify
+    "TCH", # flake8-type-checking
     "UP", # pyupgrade
     "FURB", # refurb
+    "PERF", # perflint
     "RUF", # ruff specific
+    "NPY", # NumPy specific
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,6 @@ test = [
   "pytest-sugar",
 ]
 lint = [
-  "black",
-  "isort",
-  "docformatter",
   "ruff",
   "refurb",
   "mypy",
@@ -56,11 +53,14 @@ build-backend = "setuptools.build_meta"
 version_file = "src/pyloidal/_version.py"
 fallback_version = "0.1.0"
 
-[tool.isort]
-profile = "black"
-
 [tool.ruff.lint]
-select = ["E", "F", "W", "RUF"]
+select = [
+    "F", # Pyflakes
+    "E", # pycodestyle error
+    "W", # pycodestyle warning
+    "I", # isort
+    "RUF", # ruff specific
+]
 
 [tool.coverage.run]
 relative_files = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ test = [
 ]
 lint = [
   "ruff",
-  "refurb",
   "mypy",
 ]
 
@@ -60,6 +59,8 @@ select = [
     "W", # pycodestyle warning
     "I", # isort
     "PT", # flake8-pytest-style
+    "UP", # pyupgrade
+    "FURB", # refurb
     "RUF", # ruff specific
 ]
 

--- a/src/pyloidal/cocos.py
+++ b/src/pyloidal/cocos.py
@@ -34,15 +34,14 @@ class Sigma:
 
     def __post_init__(self):
         if self.B_poloidal not in (-1, 1):
-            raise ValueError(
-                f"B_poloidal should be either 1 or -1, found {self.B_poloidal}"
-            )
+            msg = f"B_poloidal should be either 1 or -1, found {self.B_poloidal}"
+            raise ValueError(msg)
         if self.r_phi_z not in (-1, 1):
-            raise ValueError(f"r_phi_z should be either 1 or -1, found {self.r_phi_z}")
+            msg = f"r_phi_z should be either 1 or -1, found {self.r_phi_z}"
+            raise ValueError(msg)
         if self.r_theta_phi not in (-1, 1):
-            raise ValueError(
-                f"r_theta_phi should be either 1 or -1, found {self.r_theta_phi}"
-            )
+            msg = f"r_theta_phi should be either 1 or -1, found {self.r_theta_phi}"
+            raise ValueError(msg)
 
 
 SIGMA_TO_COCOS = {

--- a/src/pyloidal/cocos.py
+++ b/src/pyloidal/cocos.py
@@ -15,8 +15,8 @@ Throughout, we denote the coordinate systems in a tokamak with the following ter
 These functions were adapted from OMAS (Copyright MIT License, 2017, Orso Meneghini).
 """
 
-from dataclasses import dataclass
 import itertools
+from dataclasses import dataclass
 from typing import Optional, Tuple
 
 import numpy as np

--- a/src/pyloidal/cocos.py
+++ b/src/pyloidal/cocos.py
@@ -17,7 +17,6 @@ These functions were adapted from OMAS (Copyright MIT License, 2017, Orso Menegh
 
 import itertools
 from dataclasses import dataclass
-from typing import Optional, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
@@ -99,9 +98,9 @@ def identify_cocos(
     plasma_current: float,
     safety_factor: FloatArray,
     poloidal_flux: FloatArray,
-    clockwise_phi: Optional[bool] = None,
-    minor_radii: Optional[FloatArray] = None,
-) -> Tuple[int, ...]:
+    clockwise_phi: bool | None = None,
+    minor_radii: FloatArray | None = None,
+) -> tuple[int, ...]:
     r"""
     Determine which COCOS coordinate system is in use. Returns all possible conventions.
 

--- a/tests/test_cocos.py
+++ b/tests/test_cocos.py
@@ -1,5 +1,5 @@
 from itertools import product
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import numpy as np
 import pytest
@@ -14,16 +14,16 @@ def _identify_cocos_inputs(
     antiparallel_field_and_current: bool,
     use_minor_radii: bool,
     use_clockwise_phi: bool,
-) -> Tuple[Dict[str, Any], Tuple[int, ...]]:
+) -> tuple[dict[str, Any], tuple[int, ...]]:
     """Generates inputs for ``identify_cocos`` for a given COCOS"""
     # Set up cocos 1 kwargs and modify accordingly
-    kwargs: Dict[str, Any] = dict(
+    kwargs: dict[str, Any] = dict(
         b_toroidal=2.5,
         plasma_current=1e6,
         poloidal_flux=np.linspace(0, 2, 3),
         safety_factor=np.linspace(0.5, 1.5, 3),
     )
-    expected: List[int] = [cocos]
+    expected: list[int] = [cocos]
 
     even_cocos = not bool(cocos % 2)
     base_cocos = (cocos % 10) - even_cocos

--- a/tests/test_cocos.py
+++ b/tests/test_cocos.py
@@ -51,7 +51,7 @@ def _identify_cocos_inputs(
 
 
 @pytest.mark.parametrize(
-    "cocos,antiparallel,use_minor_radii,use_clockwise_phi",
+    ("cocos", "antiparallel", "use_minor_radii", "use_clockwise_phi"),
     product(ALL_COCOS, *(3 * [[True, False]])),
 )
 def test_identify_cocos(

--- a/tests/test_cocos.py
+++ b/tests/test_cocos.py
@@ -4,8 +4,7 @@ from typing import Any, Dict, List, Tuple
 import numpy as np
 import pytest
 
-from pyloidal.cocos import identify_cocos, Transform
-
+from pyloidal.cocos import Transform, identify_cocos
 
 ALL_COCOS = list(range(1, 9)) + list(range(11, 19))
 

--- a/tests/test_cocos.py
+++ b/tests/test_cocos.py
@@ -17,12 +17,12 @@ def _identify_cocos_inputs(
 ) -> tuple[dict[str, Any], tuple[int, ...]]:
     """Generates inputs for ``identify_cocos`` for a given COCOS"""
     # Set up cocos 1 kwargs and modify accordingly
-    kwargs: dict[str, Any] = dict(
-        b_toroidal=2.5,
-        plasma_current=1e6,
-        poloidal_flux=np.linspace(0, 2, 3),
-        safety_factor=np.linspace(0.5, 1.5, 3),
-    )
+    kwargs: dict[str, Any] = {
+        "b_toroidal": 2.5,
+        "plasma_current": 1e6,
+        "poloidal_flux": np.linspace(0, 2, 3),
+        "safety_factor": np.linspace(0.5, 1.5, 3),
+    }
     expected: list[int] = [cocos]
 
     even_cocos = not bool(cocos % 2)


### PR DESCRIPTION
Use ruff as the primary linter and formatter, and add a larger ruleset. mypy is retained for static type analysis.